### PR TITLE
Working not() with more conformant implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ UnaryTests.new(text: '> speed - speed_limit').variable_names
 ### Built-in Functions
 
 - [x] Conversion: `string`, `number`
-- [x] Boolean: `is defined`, `get or else`
+- [x] Boolean: `not`, `is defined`, `get or else`
 - [x] String: `substring`, `substring before`, `substring after`, `string length`, `upper case`, `lower case`, `contains`, `starts with`, `ends with`, `matches`, `replace`, `split`, `strip`, `extract`
 - [x] Numeric: `decimal`, `floor`, `ceiling`, `round`, `abs`, `modulo`, `sqrt`, `log`, `exp`, `odd`, `even`, `random number`
 - [x] List: `list contains`, `count`, `min`, `max`, `sum`, `product`, `mean`, `median`, `stddev`, `mode`, `all`, `any`, `sublist`, `append`, `concatenate`, `insert before`, `remove`, `reverse`, `index of`, `union`, `distinct values`, `duplicate values`, `flatten`, `sort`, `string join`

--- a/lib/spot_feel/dmn/literal_expression.rb
+++ b/lib/spot_feel/dmn/literal_expression.rb
@@ -93,7 +93,7 @@ module SpotFeel
             from.include?(".") ? from.to_f : from.to_i 
           },
           # Boolean functions
-          # "not": ->(value) { value == true ? false : true },
+          "not": ->(value) { value == true ? false : true },
           "is defined": ->(value) { 
             return if value.nil?
             !value.nil? 

--- a/lib/spot_feel/dmn/literal_expression.rb
+++ b/lib/spot_feel/dmn/literal_expression.rb
@@ -93,7 +93,11 @@ module SpotFeel
             from.include?(".") ? from.to_f : from.to_i 
           },
           # Boolean functions
-          "not": ->(value) { value == true ? false : true },
+          "not": ->(value) {
+            if value == true || value == false
+              !value
+            end
+          },
           "is defined": ->(value) { 
             return if value.nil?
             !value.nil? 

--- a/lib/spot_feel/spot_feel.treetop
+++ b/lib/spot_feel/spot_feel.treetop
@@ -629,12 +629,7 @@ grammar SpotFeel
   rule keyword
     true_token /
     false_token /
-    null_token /
-    not_token
-  end
-
-  rule not_token 
-    "not"
+    null_token
   end
 
   rule true_token

--- a/test/spot_feel/dmn/literal_expression_test.rb
+++ b/test/spot_feel/dmn/literal_expression_test.rb
@@ -69,6 +69,14 @@ module SpotFeel
           it "should eval false literal" do
             _(LiteralExpression.new(text: 'false').evaluate).must_equal false
           end
+
+          it "should eval not true literal" do
+            _(LiteralExpression.new(text: 'not(false)').evaluate).must_equal true
+          end
+
+          it "should eval not false literal" do
+            _(LiteralExpression.new(text: 'not(true)').evaluate).must_equal false
+          end
         end
 
         describe :temporal do

--- a/test/spot_feel/dmn/literal_expression_test.rb
+++ b/test/spot_feel/dmn/literal_expression_test.rb
@@ -77,6 +77,11 @@ module SpotFeel
           it "should eval not false literal" do
             _(LiteralExpression.new(text: 'not(true)').evaluate).must_equal false
           end
+
+          it "should eval not other literal" do
+            _(LiteralExpression.new(text: 'not(null)').evaluate).must_be_nil
+            _(LiteralExpression.new(text: 'not(1)'   ).evaluate).must_be_nil
+          end
         end
 
         describe :temporal do


### PR DESCRIPTION
This fixes several issues with `not()` by removing it from a keyword list which prevents it being used as a typical function, and then adds better handling of non-boolean values.

Still investigating if the keyword change is more significant than it looks, but so far so good.